### PR TITLE
SystemUI: Port statusbar brightness control

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/shade/NotificationPanelViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/shade/NotificationPanelViewController.java
@@ -3833,7 +3833,7 @@ public final class NotificationPanelViewController implements Dumpable {
         return !isDirectionUpwards(x, y);
     }
 
-    private void fling(float vel, boolean expand, boolean expandBecauseOfFalsing) {
+    public void fling(float vel, boolean expand, boolean expandBecauseOfFalsing) {
         fling(vel, expand, 1.0f /* collapseSpeedUpFactor */, expandBecauseOfFalsing);
     }
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/CentralSurfaces.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/CentralSurfaces.java
@@ -29,6 +29,7 @@ import android.os.PowerManager;
 import android.os.UserHandle;
 import android.service.notification.StatusBarNotification;
 import android.view.KeyEvent;
+import android.view.MotionEvent;
 import android.view.RemoteAnimationAdapter;
 import android.view.View;
 import android.view.ViewGroup;
@@ -558,4 +559,8 @@ public interface CentralSurfaces extends Dumpable, ActivityStarter, LifecycleOwn
     void updateDismissAllVisibility(boolean visible);
 
     void updateDismissAllButton();
+
+    void brightnessControl(MotionEvent event);
+
+    void onBrightnessChanged(boolean upOrCancel);
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/CentralSurfacesImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/CentralSurfacesImpl.java
@@ -31,6 +31,9 @@ import static androidx.core.view.ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_AUTO;
 import static androidx.core.view.ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS;
 import static androidx.lifecycle.Lifecycle.State.RESUMED;
 
+import static com.android.settingslib.display.BrightnessUtils.GAMMA_SPACE_MAX;
+import static com.android.settingslib.display.BrightnessUtils.convertGammaToLinearFloat;
+
 import static com.android.systemui.Dependency.TIME_TICK_HANDLER_NAME;
 import static com.android.systemui.charging.WirelessChargingAnimation.UNKNOWN_BATTERY_LEVEL;
 import static com.android.systemui.keyguard.WakefulnessLifecycle.WAKEFULNESS_ASLEEP;
@@ -70,9 +73,11 @@ import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
 import android.graphics.Point;
 import android.hardware.devicestate.DeviceStateManager;
+import android.hardware.display.DisplayManager;
 import android.hardware.fingerprint.FingerprintManager;
 import android.metrics.LogMaker;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Binder;
 import android.os.Bundle;
 import android.os.Handler;
@@ -96,11 +101,14 @@ import android.util.IndentingPrintWriter;
 import android.util.Log;
 import android.util.MathUtils;
 import android.view.Display;
+import android.view.HapticFeedbackConstants;
 import android.view.IRemoteAnimationRunner;
 import android.view.IWindowManager;
 import android.view.KeyEvent;
+import android.view.MotionEvent;
 import android.view.ThreadedRenderer;
 import android.view.View;
+import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.view.ViewRootImpl;
 import android.view.WindowInsetsController.Appearance;
@@ -301,6 +309,8 @@ public class CentralSurfacesImpl implements CoreStartable, CentralSurfaces, Tune
             "system:" + Settings.System.LESS_BORING_HEADS_UP;
     private static final String RETICKER_STATUS =
             "system:" + Settings.System.RETICKER_STATUS;
+    public static final String STATUS_BAR_BRIGHTNESS_CONTROL =
+            "lineagesystem:" + LineageSettings.System.STATUS_BAR_BRIGHTNESS_CONTROL;
 
     private static final String BANNER_ACTION_CANCEL =
             "com.android.systemui.statusbar.banner_action_cancel";
@@ -309,6 +319,7 @@ public class CentralSurfacesImpl implements CoreStartable, CentralSurfaces, Tune
 
     private static final int MSG_OPEN_SETTINGS_PANEL = 1002;
     private static final int MSG_LAUNCH_TRANSITION_TIMEOUT = 1003;
+    private static final int MSG_LONG_PRESS_BRIGHTNESS_CHANGE = 1004;
     // 1020-1040 reserved for BaseStatusBar
 
     /**
@@ -318,6 +329,10 @@ public class CentralSurfacesImpl implements CoreStartable, CentralSurfaces, Tune
     private static final int HINT_RESET_DELAY_MS = 1200;
 
     private static final UiEventLogger sUiEventLogger = new UiEventLoggerImpl();
+
+    private static final float BRIGHTNESS_CONTROL_PADDING = 0.15f;
+    private static final int BRIGHTNESS_CONTROL_LONG_PRESS_TIMEOUT = 750; // ms
+    private static final int BRIGHTNESS_CONTROL_LINGER_THRESHOLD = 20;
 
     private final Context mContext;
     private final LockscreenShadeTransitionController mLockscreenShadeTransitionController;
@@ -555,6 +570,19 @@ public class CentralSurfacesImpl implements CoreStartable, CentralSurfaces, Tune
     private final Provider<FingerprintManager> mFingerprintManager;
 
     private CentralSurfacesComponent mCentralSurfacesComponent;
+
+    private DisplayManager mDisplayManager;
+
+    private float mMinimumBacklight;
+    private float mMaximumBacklight;
+    private int mInitialTouchX;
+    private int mInitialTouchY;
+    private int mLinger;
+    private int mQuickQsOffsetHeight;
+    private boolean mBrightnessChanged;
+    private boolean mBrightnessControl;
+    private boolean mJustPeeked;
+    private float mCurrentBrightness;
 
     // Flags for disabling the status bar
     // Two variables because the first one evidently ran out of room for new flags.
@@ -924,6 +952,8 @@ public class CentralSurfacesImpl implements CoreStartable, CentralSurfaces, Tune
                 data -> mCommandQueueCallbacks.animateExpandSettingsPanel(data.mSubpanel));
         mMessageRouter.subscribeTo(MSG_LAUNCH_TRANSITION_TIMEOUT,
                 id -> onLaunchTransitionTimeout());
+        mMessageRouter.subscribeTo(MSG_LONG_PRESS_BRIGHTNESS_CHANGE,
+                id -> onLongPressBrightnessChange());
 
         mDeviceStateManager = deviceStateManager;
         wiredChargingRippleController.registerCallbacks();
@@ -961,6 +991,9 @@ public class CentralSurfacesImpl implements CoreStartable, CentralSurfaces, Tune
         mTunerService.addTunable(this, PULSE_ON_NEW_TRACKS);
         mTunerService.addTunable(this, LESS_BORING_HEADS_UP);
         mTunerService.addTunable(this, RETICKER_STATUS);
+        mTunerService.addTunable(this, STATUS_BAR_BRIGHTNESS_CONTROL);
+
+        mDisplayManager = mContext.getSystemService(DisplayManager.class);
 
         mWindowManager = (WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE);
 
@@ -1254,6 +1287,11 @@ public class CentralSurfacesImpl implements CoreStartable, CentralSurfaces, Tune
         mDismissAllButton = mNotificationShadeWindowView.findViewById(R.id.clear_notifications);
         updateDismissAllButton();
 
+        mMinimumBacklight = mPowerManager.getBrightnessConstraint(
+                PowerManager.BRIGHTNESS_CONSTRAINT_TYPE_MINIMUM);
+        mMaximumBacklight = mPowerManager.getBrightnessConstraint(
+                PowerManager.BRIGHTNESS_CONSTRAINT_TYPE_MAXIMUM);
+
         // TODO: Deal with the ugliness that comes from having some of the status bar broken out
         // into fragments, but the rest here, it leaves some awkward lifecycle and whatnot.
         mNotificationIconAreaController.setupShelf(mNotificationShelfController);
@@ -1280,6 +1318,7 @@ public class CentralSurfacesImpl implements CoreStartable, CentralSurfaces, Tune
                     mNotificationPanelViewController.updatePanelExpansionAndVisibility();
                     setBouncerShowingForStatusBarComponents(mBouncerShowing);
                     checkBarModes();
+                    mPhoneStatusBarViewController.setBrightnessControlEnabled(mBrightnessControl);
                     mBurnInProtectionController.setPhoneStatusBarView(mStatusBarView);
                 });
         initializer.initializeStatusBar(mCentralSurfacesComponent);
@@ -2153,6 +2192,92 @@ public class CentralSurfacesImpl implements CoreStartable, CentralSurfaces, Tune
             mNotificationPanelViewController.collapsePanel(
                     true, false /* delayed */, 1.0f /* speedUpFactor */);
         }
+    }
+
+    private void adjustBrightness(int x) {
+        mBrightnessChanged = true;
+        float raw = ((float) x) / getDisplayWidth();
+
+        // Add a padding to the brightness control on both sides to
+        // make it easier to reach min/max brightness
+        float padded = Math.min(1.0f - BRIGHTNESS_CONTROL_PADDING,
+                Math.max(BRIGHTNESS_CONTROL_PADDING, raw));
+        float value = (padded - BRIGHTNESS_CONTROL_PADDING) /
+                (1 - (2.0f * BRIGHTNESS_CONTROL_PADDING));
+        final float val = convertGammaToLinearFloat(
+                Math.round(value * GAMMA_SPACE_MAX),
+                mMinimumBacklight, mMaximumBacklight);
+        mCurrentBrightness = val;
+        mDisplayManager.setTemporaryBrightness(mDisplayId, val);
+        AsyncTask.execute(new Runnable() {
+            @Override
+            public void run() {
+                Settings.System.putFloatForUser(mContext.getContentResolver(),
+                        Settings.System.SCREEN_BRIGHTNESS_FLOAT, val,
+                        UserHandle.USER_CURRENT);
+            }
+        });
+    }
+
+    @Override
+    public void brightnessControl(MotionEvent event) {
+        final int action = event.getAction();
+        final int x = (int) event.getRawX();
+        final int y = (int) event.getRawY();
+        mQuickQsOffsetHeight = mContext.getResources().getDimensionPixelSize(
+                com.android.internal.R.dimen.quick_qs_offset_height);
+        if (action == MotionEvent.ACTION_DOWN) {
+            if (y < mQuickQsOffsetHeight) {
+                mLinger = 0;
+                mInitialTouchX = x;
+                mInitialTouchY = y;
+                mJustPeeked = true;
+                mMessageRouter.cancelMessages(MSG_LONG_PRESS_BRIGHTNESS_CHANGE);
+                mMessageRouter.sendMessageDelayed(MSG_LONG_PRESS_BRIGHTNESS_CHANGE,
+                        BRIGHTNESS_CONTROL_LONG_PRESS_TIMEOUT);
+            }
+        } else if (action == MotionEvent.ACTION_MOVE) {
+            if (y < mQuickQsOffsetHeight && mJustPeeked) {
+                if (mLinger > BRIGHTNESS_CONTROL_LINGER_THRESHOLD) {
+                    adjustBrightness(x);
+                } else {
+                    final int xDiff = Math.abs(x - mInitialTouchX);
+                    final int yDiff = Math.abs(y - mInitialTouchY);
+                    final int touchSlop = ViewConfiguration.get(mContext).getScaledTouchSlop();
+                    if (xDiff > yDiff) {
+                        mLinger++;
+                    }
+                    if (xDiff > touchSlop || yDiff > touchSlop) {
+                        mMessageRouter.cancelMessages(MSG_LONG_PRESS_BRIGHTNESS_CHANGE);
+                    }
+                }
+            } else {
+                if (y > mQuickQsOffsetHeight) {
+                    mJustPeeked = false;
+                }
+                mMessageRouter.cancelMessages(MSG_LONG_PRESS_BRIGHTNESS_CHANGE);
+            }
+        } else if (action == MotionEvent.ACTION_UP
+                || action == MotionEvent.ACTION_CANCEL) {
+            mMessageRouter.cancelMessages(MSG_LONG_PRESS_BRIGHTNESS_CHANGE);
+        }
+    }
+
+    @Override
+    public void onBrightnessChanged(boolean upOrCancel) {
+        if (mBrightnessChanged && upOrCancel) {
+            mBrightnessChanged = false;
+            if (mJustPeeked && mShadeController.isExpandedVisible()) {
+                mNotificationPanelViewController.fling(10, false, false);
+            }
+            mDisplayManager.setBrightness(mDisplayId, mCurrentBrightness);
+        }
+    }
+
+    void onLongPressBrightnessChange() {
+        mStatusBarView.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+        adjustBrightness(mInitialTouchX);
+        mLinger = BRIGHTNESS_CONTROL_LINGER_THRESHOLD + 1;
     }
 
     private void onExpandedInvisible() {
@@ -4299,6 +4424,12 @@ public class CentralSurfacesImpl implements CoreStartable, CentralSurfaces, Tune
                 boolean reTicker =
                         TunerService.parseIntegerSwitch(newValue, false);
                 mNotificationInterruptStateProvider.setUseReticker(reTicker);
+                break;
+            case STATUS_BAR_BRIGHTNESS_CONTROL:
+                mBrightnessControl =
+                        TunerService.parseIntegerSwitch(newValue, false);
+                if (mPhoneStatusBarViewController != null)
+                    mPhoneStatusBarViewController.setBrightnessControlEnabled(mBrightnessControl);
                 break;
             default:
                 break;

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java
@@ -101,6 +101,8 @@ public class PhoneStatusBarView extends FrameLayout implements Callbacks, TunerS
      */
     private int mCutoutSideNudge = 0;
 
+    private boolean mBrightnessControlEnabled;
+
     public PhoneStatusBarView(Context context, AttributeSet attrs) {
         super(context, attrs);
         mCommandQueue = Dependency.get(CommandQueue.class);
@@ -298,6 +300,14 @@ public class PhoneStatusBarView extends FrameLayout implements Callbacks, TunerS
             final boolean imeShown = (vis & InputMethodService.IME_VISIBLE) != 0;
             mRotationButtonController.getRotationButton().setCanShowRotationButton(!imeShown);
         }
+    }
+
+    public boolean getBrightnessControlEnabled() {
+        return mBrightnessControlEnabled;
+    }
+
+    public void setBrightnessControlEnabled(boolean enabled) {
+        mBrightnessControlEnabled = enabled;
     }
 
     public void updateResources() {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarViewController.kt
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarViewController.kt
@@ -113,6 +113,10 @@ class PhoneStatusBarViewController private constructor(
         mView.importantForAccessibility = mode
     }
 
+    fun setBrightnessControlEnabled(enabled: Boolean) {
+        mView.brightnessControlEnabled = enabled
+    }
+
     /**
      * Sends a touch event to the status bar view.
      *
@@ -134,13 +138,21 @@ class PhoneStatusBarViewController private constructor(
 
     /** Called when a touch event occurred on {@link PhoneStatusBarView}. */
     fun onTouch(event: MotionEvent) {
+        if (mView.brightnessControlEnabled) {
+            centralSurfaces.brightnessControl(event)
+            if (!centralSurfaces.commandQueuePanelsEnabled) return
+        }
+
+        val upOrCancel =
+                event.action == MotionEvent.ACTION_UP ||
+                event.action == MotionEvent.ACTION_CANCEL
+
         if (centralSurfaces.statusBarWindowState == WINDOW_STATE_SHOWING) {
-            val upOrCancel =
-                    event.action == MotionEvent.ACTION_UP ||
-                    event.action == MotionEvent.ACTION_CANCEL
             centralSurfaces.setInteracting(WINDOW_STATUS_BAR,
                     !upOrCancel || shadeController.isExpandedVisible)
         }
+
+        centralSurfaces.onBrightnessChanged(upOrCancel)
     }
 
     inner class PhoneStatusBarViewTouchHandler : Gefingerpoken {


### PR DESCRIPTION
This is a squash of the following changes:

Author: Danesh Mondegarian <daneshm90@gmail.com>
Date:   Sun Nov 10 23:30:56 2013 -0800

    SystemUI : Port forward statusbar brightness control

    Brings back the status bar brightness control from cm-10.2/cm-11

    Change-Id: Icc04e7da3286e9925f8b90528c1e022b33d33e9d

Author: Roman Birg <roman@cyngn.com>
Date:   Mon Dec 1 16:08:21 2014 -0800

    SystemUI: improve brightness slider behavior

    Mimic the brightness slider behavior in the statusbar.
    This adds logic to make the statusbar slider also work with automatic
    brightness mode enabled and it will instead adjust the temporary automatic
    brightness overrride.

    Change-Id: I78814a785decc83df94844fcc2f489c8cbec2b65
    Signed-off-by: Roman Birg <roman@cyngn.com>

Author: Pawit Pornkitprasan <p.pawit@gmail.com>
Date:   Sun Dec 28 20:42:41 2014 +0700

    SystemUI: status bar brightness: store value as int

    Non-automatic brightness value is stored as int, not float.

    Symptom: adjust the brightness in the status bar, the brightness
             slider in the notification bar will always be set to full

    Change-Id: I5f9a6e97bae2c44c3aff7c9222186a6dbda5d902

Author: Zhao Wei Liew <zhaoweiliew@gmail.com>
Date:   Fri Oct 7 10:09:04 2016 +0800

    SystemUI: statusbar: Fix status bar brightness control feature

    Bring in the missing fixes from CM 13.

    This commit squashes the following commits from CM 13.0:
    6397527ca0c430671503cecb69d74554dea1d399 SystemUI: fix status bar brightness slider eating events
    bbef42271cbba0eda91d214186ff2be31eb3b608 SystemUI : fix brightness slider for automatic brightness

    Change-Id: I85e0b99dc33468b36222128660707fe481cf8b33

Author: Zhao Wei Liew <zhaoweiliew@gmail.com>
Date:   Fri Oct 7 08:56:25 2016 +0800

    SystemUI: Use Tuner API for CM settings

    Get rid of all the excess code by implementing TunerService.Tunable
    and observing any changes made to the settings through it.

    Remove UserContentObserver as the Tuner API handles user switches.

    Also remove some unused imports that were introduced in earlier
    CM commits, but were never removed since.

    Change-Id: Iecafafabdaec82b3b3c72293bea865de48f0e90a

Author: Chenyang Zhong <zhongcy95@gmail.com>
Date:   Sat, 13 Mar 2021 07:36:30 -0500

    SystemUI: migrate statusbar manual brightness to float

    Google switched to float in BrightnessController after android11,
    so stay inline with that behavior. Besides, the brightness slider
    is in log scale since pie, and a gamma-to-linear conversion is
    performed when setting the value to DisplayManager. Therefore, use
    the newly introduced float conversion here to achieve a perception
    of linear brightness transitions to human eyes.

    Change-Id: I70d5e33b9464c73a25f73a1d9fc690c101b1fa05

Author: Chenyang Zhong <zhongcy95@gmail.com>
Date:   Sun, 21 Mar 2021 23:16:10 -0400

    SystemUI: unify statusbar manual & auto brightness code

    setTemporaryBrightness(float) can be used in both manual and auto
    brightness mode. This stays inline with current android11's
    BrightnessController and avoids incorrect behaviors when sliding
    statusbar in auto brightness mode.

    Change-Id: I0e7d7d0ccd871c61d062d6a190e5a61287687e80

Author: jhenrique09 <jhsv09@gmail.com>
Date:   Sat, 14 May 2022 22:51:51 +0000

    Call setBrightness when user stops swiping on statusbar

    This way brightness gets saved and changes are shown on quick settings brightness bar

    Change-Id: I5daf99d7c2c1bebf430902bdbfad9971142be93b

idoybh:
* Properly mention co-authors

cjh1249131356
* Port to QPR2

neobuddy89
* Update for LOS

Change-Id: Ic8ded146dc8605e6140f4352cafa6f961ad3decc