### PR TITLE
Conditionally disable uncrypt for ota

### DIFF
--- a/core/java/android/os/RecoverySystem.java
+++ b/core/java/android/os/RecoverySystem.java
@@ -482,7 +482,7 @@ public class RecoverySystem {
                                       final Handler handler)
             throws IOException {
         String filename = packageFile.getCanonicalPath();
-        if (!filename.startsWith("/data/")) {
+        if (!filename.startsWith("/data/") || !SystemProperties.get("persist.sys.recovery_update", "").equals("true")) {
             return;
         }
 
@@ -597,7 +597,7 @@ public class RecoverySystem {
             // If the package is on the /data partition, the package needs to
             // be processed (i.e. uncrypt'd). The caller specifies if that has
             // been done in 'processed' parameter.
-            if (filename.startsWith("/data/")) {
+            if (SystemProperties.get("persist.sys.recovery_update", "").equals("true") && filename.startsWith("/data/")) {
                 if (processed) {
                     if (!BLOCK_MAP_FILE.exists()) {
                         Log.e(TAG, "Package claimed to have been processed but failed to find "
@@ -829,7 +829,7 @@ public class RecoverySystem {
 
         // If the package is on the /data partition, use the block map file as
         // the package name instead.
-        if (filename.startsWith("/data/")) {
+        if (SystemProperties.get("persist.sys.recovery_update", "").equals("true") && filename.startsWith("/data/")) {
             filename = "@/cache/recovery/block.map";
         }
 

--- a/services/java/com/android/server/SystemServer.java
+++ b/services/java/com/android/server/SystemServer.java
@@ -1075,7 +1075,7 @@ public final class SystemServer implements Dumpable {
                         Slog.e(TAG, "Error reading uncrypt package file", e);
                     }
 
-                    if (filename != null && filename.startsWith("/data")) {
+                    if (filename != null && filename.startsWith("/data") && SystemProperties.get("persist.sys.recovery_update", "").equals("true")) {
                         if (!new File(BLOCK_MAP_FILE).exists()) {
                             Slog.e(TAG, "Can't find block map file, uncrypt failed or " +
                                     "unexpected runtime restart?");


### PR DESCRIPTION
* Some devices are getting issues, TWRP is capable to mount data and handle pin/pass on encrypted devices before running recovery commands
* Use uncrypt only if using aosp recovery

Change-Id: If6af840cbd0ee16e4dbd9d38a741c96de7f2186b