### PR TITLE
ExternalStorageProvider: Conditionally remove SAF restrictions [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -20300,6 +20300,12 @@ public final class Settings {
         public static final String RESTRICTED_NETWORKING_MODE = "restricted_networking_mode";
 
         /**
+         * Control whether to remove the restriction when selecting folders through SAF.
+         * @hide
+         */
+        public static final String NO_STORAGE_RESTRICT = "no_storage_restrict";
+
+        /**
          * Setting indicating whether Low Power Standby is enabled, if supported.
          *
          * Values are:

--- a/packages/ExternalStorageProvider/src/com/android/externalstorage/ExternalStorageProvider.java
+++ b/packages/ExternalStorageProvider/src/com/android/externalstorage/ExternalStorageProvider.java
@@ -327,6 +327,12 @@ public class ExternalStorageProvider extends FileSystemProvider {
     @Override
     protected boolean shouldBlockDirectoryFromTree(@NonNull String documentId)
             throws FileNotFoundException {
+        // Remove the restriction if user really want it.
+        if (Settings.Global.getInt(
+                getContext().getContentResolver(), Settings.Global.NO_STORAGE_RESTRICT, 0) == 1) {
+            return false;
+        }
+
         final File dir = getFileForDocId(documentId, false);
         // The file is null or it is not a directory
         if (dir == null || !dir.isDirectory()) {


### PR DESCRIPTION
* Original commit gutted out entire codes in shouldBlockDirectoryFromTree which could be lead to major privacy leakage due to those invasive apps' behavior

* Add toggle instead so that users could opt in/out

Original commit msg:
    ExternalStorageProvider: Remove SAF restrictions

    * Inspired by https://github.com/DanGLES3/NoStorageRestrict

    Change-Id: I073d9bb8edd49224e17c76a43683365a64686768
    Signed-off-by: Richard Raya <rdxzv.dev@gmail.com>
    Signed-off-by: Gustavo Mendes <gusttavo.me@outlook.com>

Change-Id: I9f987b7dae80af95275f743cfbc935582ff2129e