### PR TITLE
Add MIUI camera patches for sdm 660-665 devices [1/2]

### DIFF
--- a/core/java/android/hardware/camera2/CameraManager.java
+++ b/core/java/android/hardware/camera2/CameraManager.java
@@ -870,8 +870,14 @@ public final class CameraManager {
         HashMap<String, CameraCharacteristics> physicalIdsToChars =
                 new HashMap<String, CameraCharacteristics>();
         Set<String> physicalCameraIds = chars.getPhysicalCameraIds();
+        CameraCharacteristics physicalChars;
         for (String physicalCameraId : physicalCameraIds) {
-            CameraCharacteristics physicalChars = getCameraCharacteristics(physicalCameraId);
+            try {
+                physicalChars = getCameraCharacteristics(physicalCameraId);
+            } catch (Exception e) {
+                physicalCameraId = "20";
+                physicalChars = getCameraCharacteristics(physicalCameraId);
+            }
             physicalIdsToChars.put(physicalCameraId, physicalChars);
         }
         return physicalIdsToChars;


### PR DESCRIPTION
 * miui camera uses logical id 61 as depth sensor on portrait mode but oss libcam maps it to physical id 2 which is wrong, our physical id of depth sensor is 20 so we must hack it this way

[garry-rogov 2024-03-31]
 * updated for android 14 QPR2

Change-Id: Icb04ebcfc3b2d3c19a434303d9b6b7822c3d9355